### PR TITLE
Add newline between option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # merge-maven-plugin
-Maven(3) plugin which merges multiple files into one
+Maven(3) plugin which merges multiple text files into one
 
 ## Simple Configuration example
 <pre>
@@ -40,6 +40,7 @@ Maven(3) plugin which merges multiple files into one
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;source&gt;src/main/resources/input1.txt&lt;/source&gt;
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;source&gt;src/main/resources/inputn.txt&lt;/source&gt;
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;/sources&gt;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;newLineBetween&gt;false&lt;/newLineBetween&gt;
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;/merger&gt;
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;/mergers&gt;
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;/configuration&gt;
@@ -51,5 +52,19 @@ Maven(3) plugin which merges multiple files into one
 </pre>
 
 ## How to run?
-At the moment do <code>mvn org.zcore.maven:merge-maven-plugin:merge</code>.
-<small>This will be easier in the future</small>
+From the CLI use <code>mvn org.zcore.maven:merge-maven-plugin:merge</code>, but within the POM it can be easily connected to a phase (most common would be <code>package</code>):
+
+<pre>
+&lt;plugin&gt;
+&nbsp;…
+&nbsp;&lt;executions&gt;
+&nbsp;&nbsp;&lt;execution&gt;
+&nbsp;&nbsp;&nbsp;&lt;id&gt;merge-files&lt;/id&gt;
+&nbsp;&nbsp;&nbsp;&lt;phase&gt;package&lt;/phase&gt;
+&nbsp;&nbsp;&nbsp;&lt;goals&gt;
+&nbsp;&nbsp;&nbsp;&nbsp;&lt;goal&gt;merge&lt;/goal&gt;
+&nbsp;&nbsp;&nbsp;&lt;/goals&gt;
+&nbsp;&nbsp;&lt;/execution&gt;
+&nbsp;&lt;/executions&gt;
+&lt;/plugin&gt;
+</pre>

--- a/pom.xml
+++ b/pom.xml
@@ -1,198 +1,207 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>org.zcore.maven</groupId>
-  <artifactId>merge-maven-plugin</artifactId>
-  <version>0.0.5-SNAPSHOT</version>
-  <packaging>maven-plugin</packaging>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.zcore.maven</groupId>
+    <artifactId>merge-maven-plugin</artifactId>
+    <version>0.0.5</version>
+    <packaging>maven-plugin</packaging>
 
-  <name>Maven Merge Plugin</name>
-  <description>Merges multiple files into one</description>
-  <url>http://www.zcore.org/merge-maven-plugin</url>
-  <inceptionYear>2013</inceptionYear>
-  <organization>
-    <name>ZCore</name>
-    <url>http://www.zcore.org</url>
-  </organization>
-  <licenses>
-    <license>
-      <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-    </license>
-  </licenses>
+    <name>Maven Merge Plugin</name>
+    <description>Merges multiple files into one</description>
+    <url>http://www.zcore.org/merge-maven-plugin</url>
+    <inceptionYear>2013</inceptionYear>
+    <organization>
+        <name>ZCore</name>
+        <url>http://www.zcore.org</url>
+    </organization>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
 
-  <developers>
-    <developer>
-      <id>rob</id>
-      <name>Robert Heine</name>
-      <email>robert.heine@zcore.org</email>
-      <url>http://www.zcore.org</url>
-      <organization>Zcore</organization>
-      <organizationUrl>http://www.zcore.org</organizationUrl>
-      <roles>
-        <role>owner</role>
-      </roles>
-      <timezone>+1</timezone>
-    </developer>
-    <developer>
-      <id>am</id>
-      <name>André Morassut</name>
-      <email>andre.morassut@gmail.com</email>
-      <roles>
-        <role>contributor</role>
-      </roles>
-      <timezone>+1</timezone>
-    </developer>    
-  </developers>
-  
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
-  
-  <issueManagement>
-    <system>GitHub</system>
-    <url>https://github.com/andre-morassut/merge-maven-plugin</url>
-  </issueManagement>
+    <developers>
+        <developer>
+            <id>rob</id>
+            <name>Robert Heine</name>
+            <email>robert.heine@zcore.org</email>
+            <url>http://www.zcore.org</url>
+            <organization>Zcore</organization>
+            <organizationUrl>http://www.zcore.org</organizationUrl>
+            <roles>
+                <role>owner</role>
+            </roles>
+            <timezone>+1</timezone>
+        </developer>
+        <developer>
+            <id>am</id>
+            <name>André Morassut</name>
+            <email>andre.morassut@gmail.com</email>
+            <roles>
+                <role>contributor</role>
+            </roles>
+            <timezone>+1</timezone>
+        </developer>
+        <developer>
+            <id>vovtz</id>
+            <name>Vincent van ’t Zand</name>
+            <roles>
+                <role>contributor</role>
+            </roles>
+            <timezone>+1</timezone>
+        </developer>
+    </developers>
 
-  <distributionManagement>
-    <repository>
-      <id>sonatype-stages</id>
-      <name>Stages repository at oss.sonatype.org</name>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-    </repository>
-    <snapshotRepository>
-      <id>sonatype-snapshots</id>
-      <name>Snapshot repository at oss.sonataype.org</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
-  <scm>
-    <connection>scm:git:https://github.com/andre-morassut/merge-maven-plugin.git</connection>
-    <url>https://github.com/andre-morassut/merge-maven-plugin.git</url>
-    <developerConnection>scm:git:https://github.com/andre-morassut/merge-maven-plugin.git</developerConnection>
-    <tag>HEAD</tag>
-  </scm>
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/andre-morassut/merge-maven-plugin</url>
+    </issueManagement>
 
-  <prerequisites>
-    <maven>3.0.4</maven>
-  </prerequisites>
+    <distributionManagement>
+        <repository>
+            <id>sonatype-stages</id>
+            <name>Stages repository at oss.sonatype.org</name>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+        </repository>
+        <snapshotRepository>
+            <id>sonatype-snapshots</id>
+            <name>Snapshot repository at oss.sonataype.org</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
 
-  <build>
-    <defaultGoal>install</defaultGoal>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.4</version>
-        <configuration>
-          <mavenExecutorId>forked-path</mavenExecutorId>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.4</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>license-maven-plugin</artifactId>
-        <version>1.4</version>
-        <configuration>
-        <licenseName>apache_v2</licenseName>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9</version>
-				<configuration>
-					<additionalparam>-Xdoclint:none</additionalparam>
-					<tags>
-						<tag>
-							<name>goal</name>
-							<placement>a</placement>
-							<head>Maven goal annotation value:</head>
-						</tag>
-						<tag>
-							<name>requiresProject</name>
-							<placement>a</placement>
-							<head>Maven requiresProject annotation value:</head>
-						</tag>						
-					</tags>
-				</configuration>
-      </plugin>			
-    </plugins>
-  </build>
+    <scm>
+        <connection>scm:git:https://github.com/andre-morassut/merge-maven-plugin.git</connection>
+        <url>https://github.com/andre-morassut/merge-maven-plugin.git</url>
+        <developerConnection>scm:git:https://github.com/andre-morassut/merge-maven-plugin.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
 
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-plugin-plugin</artifactId>
-        <version>2.9</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.1.2</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9</version>
-				<configuration>
-					<additionalparam>-Xdoclint:none</additionalparam>
-					<tags>
-						<tag>
-							<name>goal</name>
-							<placement>a</placement>
-							<head>Maven goal annotation value:</head>
-						</tag>
-						<tag>
-							<name>requiresProject</name>
-							<placement>a</placement>
-							<head>Maven requiresProject annotation value:</head>
-						</tag>						
-					</tags>
-				</configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>2.1</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-report-plugin</artifactId>
-        <version>2.4.3</version>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>license-maven-plugin</artifactId>
-        <version>1.4</version>
-      </plugin>
-    </plugins>
-  </reporting>
+    <prerequisites>
+        <maven>3.0.4</maven>
+    </prerequisites>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-plugin-api</artifactId>
-      <version>3.0.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.plugin-tools</groupId>
-      <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.2</version>
-    </dependency>
-  </dependencies>
+    <build>
+        <defaultGoal>install</defaultGoal>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <mavenExecutorId>forked-path</mavenExecutorId>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.4</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>1.4</version>
+                <configuration>
+                    <licenseName>apache_v2</licenseName>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9</version>
+                <configuration>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <tags>
+                        <tag>
+                            <name>goal</name>
+                            <placement>a</placement>
+                            <head>Maven goal annotation value:</head>
+                        </tag>
+                        <tag>
+                            <name>requiresProject</name>
+                            <placement>a</placement>
+                            <head>Maven requiresProject annotation value:</head>
+                        </tag>
+                    </tags>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>2.9</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>2.1.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9</version>
+                <configuration>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <tags>
+                        <tag>
+                            <name>goal</name>
+                            <placement>a</placement>
+                            <head>Maven goal annotation value:</head>
+                        </tag>
+                        <tag>
+                            <name>requiresProject</name>
+                            <placement>a</placement>
+                            <head>Maven requiresProject annotation value:</head>
+                        </tag>
+                    </tags>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <version>2.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-report-plugin</artifactId>
+                <version>2.4.3</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>1.4</version>
+            </plugin>
+        </plugins>
+    </reporting>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>3.0.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.2</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/src/main/java/org/zcore/maven/MergeMojo.java
+++ b/src/main/java/org/zcore/maven/MergeMojo.java
@@ -23,6 +23,7 @@ import org.apache.maven.plugin.MojoFailureException;
  *
  * @author Robert Heine
  * @author André Morassut
+ * @author Vincent van ’t Zand
  * @goal merge
  * @requiresProject true
  */
@@ -52,7 +53,7 @@ public class MergeMojo extends AbstractMojo {
 
 	/**
 	 * Opens an OutputStream, based on the supplied file
-	 * 
+	 *
 	 * @param file {@linkplain File} the output file
 	 * @return {@linkplain OutputStream} the output stream to the parameter file
 	 * @throws MojoExecutionException if file is a directory, not writable, or other problem
@@ -97,7 +98,7 @@ public class MergeMojo extends AbstractMojo {
 
 	/**
 	 * Opens an InputStream, based on the supplied file
-	 * 
+	 *
 	 * @param file {@linkplain File} the source file
 	 * @return {@linkplain InputStream} the input stream of the parameter file
 	 * @throws MojoExecutionException If file has a problem
@@ -121,7 +122,7 @@ public class MergeMojo extends AbstractMojo {
 
 	/**
 	 * Factory Execute
-	 * 
+	 *
 	 * @throws MojoExecutionException if file write operation went wrong
 	 * @throws MojoFailureException for plugin failure
 	 */
@@ -135,7 +136,7 @@ public class MergeMojo extends AbstractMojo {
 			sourcesIs = new ArrayList<InputStream>(sources.length * 2);
 			for (File source : sources) {
 				sourcesIs.add(initInput(source)); // add source stream
-				if (getNewLineBetween()) {
+				if (merger.getNewLineBetween()) {
 					sourcesIs.add(new ByteArrayInputStream(System.getProperty("line.separator").getBytes())); // add line separator
 				}
 			}

--- a/src/main/java/org/zcore/maven/MergeMojo.java
+++ b/src/main/java/org/zcore/maven/MergeMojo.java
@@ -135,7 +135,9 @@ public class MergeMojo extends AbstractMojo {
 			sourcesIs = new ArrayList<InputStream>(sources.length * 2);
 			for (File source : sources) {
 				sourcesIs.add(initInput(source)); // add source stream
-				sourcesIs.add(new ByteArrayInputStream(System.getProperty("line.separator").getBytes())); // add line separator
+				if (getNewLineBetween()) {
+					sourcesIs.add(new ByteArrayInputStream(System.getProperty("line.separator").getBytes())); // add line separator
+				}
 			}
 			// write to file
 			try {

--- a/src/main/java/org/zcore/maven/Merger.java
+++ b/src/main/java/org/zcore/maven/Merger.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 
 /**
  * PoJo holding information for text file merging
- * 
+ *
  * @author Robert Heine
  * @author Vincent van ’t Zand
  */
@@ -13,7 +13,7 @@ public class Merger {
 
 	/**
 	 * The target file, where all other files are copied to
-	 * 
+	 *
 	 * @parameter
 	 * @required
 	 */
@@ -21,7 +21,7 @@ public class Merger {
 
 	/**
 	 * Array of possible source files
-	 * 
+	 *
 	 * @parameter
 	 * @required
 	 */
@@ -29,22 +29,22 @@ public class Merger {
 
 	/**
 	 * If this is set, strip all newlines and rewrite them with specified characters
-	 * 
+	 *
 	 * @parameter
 	 */
 	private transient String rewriteNewlines;
 
 	/**
 	 * This determines if a new line character is written after each file used in the merge. The
-	 * default value is false for backwards compatibility.
-	 * 
+	 * default value is true for backwards compatibility.
+	 *
 	 * @parameter
 	 */
-	private transient Boolean newLineBetween = false;
+	private transient Boolean newLineBetween = true;
 
 	/**
 	 * Returns the target filename
-	 * 
+	 *
 	 * @return {@linkplain File} target file
 	 */
 	public File getTarget() {
@@ -53,7 +53,7 @@ public class Merger {
 
 	/**
 	 * Returns the array of source filenames
-	 * 
+	 *
 	 * @return array of {@linkplain File}
 	 */
 	public File[] getSources() {
@@ -62,7 +62,7 @@ public class Merger {
 
 	/**
 	 * Returns rewriting newlines
-	 * 
+	 *
 	 * @return rewriteNewLines attribute
 	 */
 	public String getRewriteNewlines() {
@@ -77,10 +77,10 @@ public class Merger {
 	public Boolean getNewLineBetween() {
 		return newLineBetween;
 	}
-	
+
 	/**
 	 * Overriding toString() here for debugging
-	 * 
+	 *
 	 * @return {@linkplain String} string representation
 	 */
 	@Override
@@ -93,7 +93,7 @@ public class Merger {
 		buffer.append("[source: ").append(Arrays.asList(getSources().toString())).append(']');
 		/**
 		 * Append rewriting char for newlines
-		 * 
+		 *
 		 * @since 2013-02-12
 		 */
 		if (null != rewriteNewlines) {

--- a/src/main/java/org/zcore/maven/Merger.java
+++ b/src/main/java/org/zcore/maven/Merger.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
  * PoJo holding information for text file merging
  * 
  * @author Robert Heine
- *
+ * @author Vincent van ’t Zand
  */
 public class Merger {
 
@@ -33,6 +33,14 @@ public class Merger {
 	 * @parameter
 	 */
 	private transient String rewriteNewlines;
+
+	/**
+	 * This determines if a new line character is written after each file used in the merge. The
+	 * default value is false for backwards compatibility.
+	 * 
+	 * @parameter
+	 */
+	private transient Boolean newLineBetween = false;
 
 	/**
 	 * Returns the target filename
@@ -62,6 +70,15 @@ public class Merger {
 	}
 
 	/**
+	 * Returns if new lines should be added between each of the files to merge
+	 *
+	 * @return Value of newLineBetween attribute
+	 */
+	public Boolean getNewLineBetween() {
+		return newLineBetween;
+	}
+	
+	/**
 	 * Overriding toString() here for debugging
 	 * 
 	 * @return {@linkplain String} string representation
@@ -82,6 +99,7 @@ public class Merger {
 		if (null != rewriteNewlines) {
 			buffer.append("[newline: ").append(rewriteNewlines).append(']');
 		}
+		buffer.append("[newLineBetween: ").append(getNewLineBetween() ? "yes" : "no").append(']');
 		// return
 		return buffer.toString();
 	}


### PR DESCRIPTION
Hi André,

I have a use case which doesn’t cope with the newlines that the current version always adds between each source file in the merge. So I added an option to leave out these additional newlines; it defaults to off for backwards compatibility.

Best regards, Vincent van ’t Zand

PS I didn’t compile and test yet! (Typed everything from within GitHub.) Will let you know if all’s well (will retract merge request if not).